### PR TITLE
add GRASS GIS to xfce4 panel

### DIFF
--- a/system/roles/client-desktop/templates/desktop/panel/default.xml
+++ b/system/roles/client-desktop/templates/desktop/panel/default.xml
@@ -15,7 +15,10 @@
         <value type="int" value="18"/>
         <value type="int" value="12"/>
         <value type="int" value="8"/>
-{% if GISLAB_SUITE == 'lab' %}<value type="int" value="9"/>{% endif %}
+{% if GISLAB_SUITE == 'lab' %}
+        <value type="int" value="9"/>
+	<value type="int" value="19"/>
+{% endif %}
         <value type="int" value="15"/>
         <value type="int" value="26"/>
         <value type="int" value="2"/>
@@ -87,6 +90,11 @@
     <property name="plugin-9" type="string" value="launcher">
       <property name="items" type="array">
         <value type="string" value="gislab-desktop.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-19" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="gislab-grass.desktop"/>
       </property>
     </property>
 {% endif %}


### PR DESCRIPTION
This patch adds GRASS GIS to the xfce4 client's panel.